### PR TITLE
I18n

### DIFF
--- a/student/dcm1/AI_Context.md
+++ b/student/dcm1/AI_Context.md
@@ -23,6 +23,128 @@ cmake --build build --config Release
 - Cle QSettings reservee : `ui/language`
 - Etat actuel : cle initialisee au demarrage, sans effet fonctionnel sur l'UI
 
+## i18n (phase 2) - inventaire des chaines
+
+Inventaire effectue sur `Window.cpp`, `Barres.cpp`, `MechanismRenderer.cpp`.
+
+### Chaines UI a traduire (FR/EN)
+
+- Fenetre principale / groupes:
+  - `Barres`
+  - `Parameters`
+  - `Animation`
+  - `Vitesse`
+  - ` ms/frame`
+  - `Intervalle entre deux frames d'animation`
+  - `Vitesse animation: %1 ms/frame`
+
+- Menus / actions:
+  - `&Fichier`, `&Importer parametres...`, `&Exporter parametres...`, `&Quitter`
+  - `&Affichage`, `Réinitialiser la vue`, `Parametres de dessin...`
+  - `&Animation`, `&Démarrer`, `&Arrêter`
+  - `&Aide`, `&A propos`
+
+- Sliders (labels + tooltips):
+  - `a1`, `a2`, `a3`, `xb`, `ya`, `L`, `e`, `dp`
+  - `Longueur AD (manivelle)`
+  - `Longueur DC (bielle)`
+  - `Longueur BC (balancier)`
+  - `Position x du pivot B`
+  - `Position y du pivot A`
+  - `Longueur DP' (point outil)`
+  - `Offset vertical du film`
+  - `Distance P' -> P`
+
+- Dialog "Parametres de dessin":
+  - Titres / onglets: `Parametres de dessin`, `Traits`, `Labels`, `Couleurs`
+  - Champs:
+    - `Epaisseur liens`
+    - `Epaisseur trajectoire P`
+    - `Epaisseur trajectoire D`
+    - `Demi-longueur sol`
+    - `Longueur film`
+    - `Taille police`
+    - `Offset X`, `Offset Y`
+    - `Choisir...`
+    - `Couleur principale`
+    - `Couleur trajectoire P`
+    - `Couleur trajectoire D`
+    - `Trajectoire P`, `Trajectoire D`
+    - `Reinitialiser`
+  - Status bar associee: `Style de dessin applique`
+
+- Import / export JSON (messages utilisateur):
+  - Selecteurs:
+    - `Importer les parametres`
+    - `Exporter les parametres`
+    - `JSON files (*.json)`
+  - Erreurs export:
+    - `Export impossible`
+    - `Impossible d'ouvrir le fichier pour ecriture.`
+    - `Echec de l'export JSON`
+    - `Export incomplet`
+    - `Le fichier n'a pas ete ecrit completement.`
+    - `Export JSON incomplet`
+    - `Parametres exportes en JSON`
+  - Erreurs import:
+    - `Import impossible`
+    - `Impossible d'ouvrir le fichier en lecture.`
+    - `Echec de l'import JSON`
+    - `Format invalide`
+    - `Le fichier JSON est invalide.`
+    - `JSON invalide`
+    - `Format non reconnu`
+    - `Le fichier n'est pas un export Barres.`
+    - `Format JSON non reconnu`
+    - `Version non supportee`
+    - `Version de fichier non supportee.`
+    - `Version JSON non supportee`
+    - `Fichier incomplet`
+    - `Objet 'params' manquant.`
+    - `Objet params manquant`
+    - `Parametres invalides`
+    - `Un ou plusieurs parametres sont manquants ou hors bornes.`
+    - `Parametres JSON invalides`
+    - `Parametres importes depuis JSON`
+    - `Deposer un fichier .json valide`
+
+- A propos / status / raccourcis:
+  - Titre: `A propos`
+  - Contenu complet de la boite "A propos"
+  - `Affichage de la boite A propos`
+  - `Animation demarree`
+  - `Animation arretee`
+  - `Animation reinitialisee`
+  - `Frame precedente`
+  - `Frame suivante`
+  - `Pret`
+
+- Rendu (`MechanismRenderer.cpp`):
+  - Labels points: `A`, `B`, `C`, `D`, `P'`, `P`
+  - Overlay frame: `frame=%1/%2`
+  - Overlay angles: `thetaAD=%1 deg\nthetaDC=%2 deg\nthetaBC=%3 deg`
+
+- Widget rendu (`Barres.cpp`):
+  - `Barres! (DCM1-1994)`
+
+### Chaines a ne pas traduire (stabilite format / technique)
+
+- Cles QSettings:
+  - `io/lastParamsDir`, `window/size`, `ui/language`
+  - `view/zoom`, `view/panOffsetX`, `view/panOffsetY`
+  - `animation/intervalMs`
+  - `render/*`
+
+- Format JSON import/export:
+  - `format`, `version`, `savedAt`, `params`
+  - `barres-params`
+  - Noms de parametres: `a1`, `a2`, `a3`, `xb`, `ya`, `L`, `e`, `dp`
+
+- Chaines purement techniques:
+  - Feuille de style: `QPushButton { background-color: %1; color: %2; }`
+  - Valeurs CSS: `white`, `black`
+  - Extension/filtre de suffixe: `json`
+
 ---
 
 ## Structure des fichiers

--- a/student/dcm1/AI_Context.md
+++ b/student/dcm1/AI_Context.md
@@ -23,6 +23,18 @@ cmake --build build --config Release
 - Cle QSettings reservee : `ui/language`
 - Etat actuel : cle initialisee au demarrage, sans effet fonctionnel sur l'UI
 
+## i18n (etat courant)
+
+- Les textes UI principaux sont passes par `tr(...)` / `QCoreApplication::translate(...)`.
+- Infrastructure Qt Linguist activee dans `CMakeLists.txt`:
+  - fichier source de traduction: `i18n/barres_en.ts`
+  - generation du binaire `barres_en.qm` au build
+  - copie post-build vers `build/Release/i18n/barres_en.qm`
+- `main.cpp` charge `barres_en.qm` si `ui/language = "en"`.
+- Francais reste la langue source par defaut (si `ui/language = "fr"`).
+- Menu de selection langue ajoute: `Affichage -> Langue -> Francais/Anglais`.
+- Le changement de langue est persiste dans QSettings, applique au prochain demarrage.
+
 ## i18n (phase 2) - inventaire des chaines
 
 Inventaire effectue sur `Window.cpp`, `Barres.cpp`, `MechanismRenderer.cpp`.
@@ -306,7 +318,7 @@ Clés utilisées :
 | Clé | Type | Usage |
 |---|---|---|
 | `io/lastParamsDir` | QString | Dernier répertoire import/export JSON |
-| `ui/language` | QString (`fr`/`en`) | Préférence langue UI (réservée, non appliquée en phase 1) |
+| `ui/language` | QString (`fr`/`en`) | Préférence langue UI (chargée au démarrage) |
 | `view/zoom` | double | Niveau de zoom sauvé |
 | `view/panOffsetX` | int | Décalage horizontal de la vue |
 | `view/panOffsetY` | int | Décalage vertical de la vue |

--- a/student/dcm1/AI_Context.md
+++ b/student/dcm1/AI_Context.md
@@ -16,6 +16,13 @@ cmake --build build --config Release
 # produit : build/Release/barres.exe
 ```
 
+## i18n (phase 1)
+
+- Branche de travail recommandee : `i18n-step1`
+- Convention de langue cible : `fr` (par defaut) / `en`
+- Cle QSettings reservee : `ui/language`
+- Etat actuel : cle initialisee au demarrage, sans effet fonctionnel sur l'UI
+
 ---
 
 ## Structure des fichiers
@@ -177,6 +184,7 @@ Clés utilisées :
 | Clé | Type | Usage |
 |---|---|---|
 | `io/lastParamsDir` | QString | Dernier répertoire import/export JSON |
+| `ui/language` | QString (`fr`/`en`) | Préférence langue UI (réservée, non appliquée en phase 1) |
 | `view/zoom` | double | Niveau de zoom sauvé |
 | `view/panOffsetX` | int | Décalage horizontal de la vue |
 | `view/panOffsetY` | int | Décalage vertical de la vue |

--- a/student/dcm1/Barres.cpp
+++ b/student/dcm1/Barres.cpp
@@ -167,7 +167,7 @@ Barres::Barres(QWidget *parent)
     params.e = 1.4595;
     params.dp = 0.5459; // PP'
 
-    this->setWindowTitle("Barres! (DCM1-1994)");
+    this->setWindowTitle(tr("Barres! (DCM1-1994)"));
     this->resize(640, 480);
 
     renderStyle = loadRenderStyleFromSettings();

--- a/student/dcm1/Barres.cpp
+++ b/student/dcm1/Barres.cpp
@@ -114,6 +114,23 @@ void loadViewFromSettings(double &zoom, QPoint &panOffset)
     panOffset = QPoint(settings.value("view/panOffsetX", 150).toInt(),
                        settings.value("view/panOffsetY", 300).toInt());
 }
+
+int loadAnimationIntervalFromSettings()
+{
+    QSettings settings;
+    int intervalMs = settings.value("animation/intervalMs", 25).toInt();
+    if (intervalMs < 5)
+        intervalMs = 5;
+    if (intervalMs > 200)
+        intervalMs = 200;
+    return intervalMs;
+}
+
+void saveAnimationIntervalToSettings(int intervalMs)
+{
+    QSettings settings;
+    settings.setValue("animation/intervalMs", intervalMs);
+}
 } // namespace
 
 Barres::Barres(QWidget *parent)
@@ -155,6 +172,7 @@ Barres::Barres(QWidget *parent)
 
     renderStyle = loadRenderStyleFromSettings();
     loadViewFromSettings(zoom, panOffset);
+    animationIntervalMs = loadAnimationIntervalFromSettings();
 
     frame = 1;
     myTimerId = 0;
@@ -319,7 +337,7 @@ Barres::startAnimation()
 {
     if (myTimerId == 0)
     {
-        myTimerId = startTimer(25);
+        myTimerId = startTimer(animationIntervalMs);
         emit animationStarted();
     }
 }
@@ -342,6 +360,33 @@ Barres::toggleAnimation()
         startAnimation();
     else
         stopAnimation();
+}
+
+int
+Barres::currentAnimationIntervalMs() const
+{
+    return animationIntervalMs;
+}
+
+void
+Barres::setAnimationIntervalMs(int intervalMs)
+{
+    if (intervalMs < 5)
+        intervalMs = 5;
+    if (intervalMs > 200)
+        intervalMs = 200;
+
+    if (animationIntervalMs == intervalMs)
+        return;
+
+    animationIntervalMs = intervalMs;
+    saveAnimationIntervalToSettings(animationIntervalMs);
+
+    if (myTimerId != 0)
+    {
+        killTimer(myTimerId);
+        myTimerId = startTimer(animationIntervalMs);
+    }
 }
 
 void

--- a/student/dcm1/Barres.h
+++ b/student/dcm1/Barres.h
@@ -45,6 +45,7 @@ class Barres : public QWidget
 
     int myTimerId;
     int frame;
+    int animationIntervalMs;
 
 public:
     Barres(QWidget *parent = nullptr);
@@ -52,6 +53,7 @@ public:
     void applyParameters(const MechanismParameters &newParams);
     RenderStyleSettings currentRenderStyle() const;
     void applyRenderStyle(const RenderStyleSettings &newStyle);
+    int currentAnimationIntervalMs() const;
 
 protected:
     void paintEvent(QPaintEvent *event) override;
@@ -76,6 +78,7 @@ public slots:
     void startAnimation();
     void stopAnimation();
     void toggleAnimation();
+    void setAnimationIntervalMs(int intervalMs);
     void resetAnimation();
     void resetView();
     void stepForward();

--- a/student/dcm1/CMakeLists.txt
+++ b/student/dcm1/CMakeLists.txt
@@ -8,7 +8,28 @@ endif()
 
 set(CMAKE_AUTOMOC ON)
 
-find_package(Qt5 COMPONENTS Widgets REQUIRED)
+find_package(Qt5 COMPONENTS Widgets LinguistTools REQUIRED)
+
+set(TS_FILES
+    i18n/barres_en.ts
+)
+
+set(TS_SOURCES
+    main.cpp
+    Window.cpp
+    Window.h
+    Barres.cpp
+    Barres.h
+    MechanismKinematicsSolver.cpp
+    MechanismKinematicsSolver.h
+    MechanismRenderer.cpp
+    MechanismRenderer.h
+)
+
+qt5_create_translation(QM_FILES
+    ${TS_SOURCES}
+    ${TS_FILES}
+)
 
 add_executable(barres)
 target_sources(barres PRIVATE
@@ -21,9 +42,16 @@ target_sources(barres PRIVATE
     MechanismKinematicsSolver.h
     MechanismRenderer.cpp
     MechanismRenderer.h
+    ${TS_FILES}
+    ${QM_FILES}
 )
 target_compile_features(barres PRIVATE cxx_std_11)
 target_link_libraries(barres PRIVATE Qt5::Widgets)
+
+add_custom_command(TARGET barres POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E make_directory $<TARGET_FILE_DIR:barres>/i18n
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${QM_FILES} $<TARGET_FILE_DIR:barres>/i18n
+)
 
 add_executable(mechanism_kinematics_solver_test)
 target_sources(mechanism_kinematics_solver_test PRIVATE

--- a/student/dcm1/MechanismRenderer.cpp
+++ b/student/dcm1/MechanismRenderer.cpp
@@ -13,7 +13,50 @@
 //   limitations under the License.
 
 #include "MechanismRenderer.h"
+#include <cmath>
 #include <QPen>
+
+namespace
+{
+double normalizeAngleDegrees(double angleDeg)
+{
+    while (angleDeg < 0.0)
+        angleDeg += 360.0;
+    while (angleDeg >= 360.0)
+        angleDeg -= 360.0;
+    return angleDeg;
+}
+
+void drawWorldGrid(QPainter &painter, const QRect &widgetRect,
+                   int ox, int oy, double zoom)
+{
+    double worldStep = 1.0;
+    while (worldStep * zoom < 25.0)
+        worldStep *= 2.0;
+    while (worldStep * zoom > 120.0)
+        worldStep *= 0.5;
+
+    const double stepPx = worldStep * zoom;
+    const int left = widgetRect.left();
+    const int right = widgetRect.right();
+    const int top = widgetRect.top();
+    const int bottom = widgetRect.bottom();
+
+    painter.setPen(QPen(QColor(220, 220, 220), 1.0));
+
+    double x = ox + std::floor((left - ox) / stepPx) * stepPx;
+    for (; x <= right; x += stepPx)
+        painter.drawLine(QPointF(x, top), QPointF(x, bottom));
+
+    double y = oy + std::floor((top - oy) / stepPx) * stepPx;
+    for (; y <= bottom; y += stepPx)
+        painter.drawLine(QPointF(left, y), QPointF(right, y));
+
+    painter.setPen(QPen(QColor(170, 170, 170), 1.4));
+    painter.drawLine(QPointF(ox, top), QPointF(ox, bottom));
+    painter.drawLine(QPointF(left, oy), QPointF(right, oy));
+}
+} // namespace
 
 void
 MechanismRenderer::draw(QPainter &painter, const TrajectoryGeometry &geometry,
@@ -27,6 +70,8 @@ MechanismRenderer::draw(QPainter &painter, const TrajectoryGeometry &geometry,
     auto pt = [&geometry, &sx, &sy](int p, int f) {
         return QPointF(sx(geometry.x[p][f]), sy(geometry.y[p][f]));
     };
+
+    drawWorldGrid(painter, widgetRect, ox, oy, zoom);
 
     QPen pen1(style.mainColor, style.linkPenWidth);
     // pen.setColor(palette().dark().color());
@@ -87,4 +132,25 @@ MechanismRenderer::draw(QPainter &painter, const TrajectoryGeometry &geometry,
     painter.setPen(QPen(Qt::black));
     painter.drawText(widgetRect, Qt::AlignHCenter | Qt::AlignTop,
                      QString("frame=%1/%2").arg(frame).arg(nframes));
+
+    const auto angleDeg = [](double vx, double vy) {
+        const double pi = 3.14159265358979323846;
+        const double rad = std::atan2(vy, vx);
+        return normalizeAngleDegrees(rad * 180.0 / pi);
+    };
+
+    const double thetaAD = angleDeg(geometry.x[D][frame] - geometry.x[A][frame],
+                                    geometry.y[D][frame] - geometry.y[A][frame]);
+    const double thetaDC = angleDeg(geometry.x[C][frame] - geometry.x[D][frame],
+                                    geometry.y[C][frame] - geometry.y[D][frame]);
+    const double thetaBC = angleDeg(geometry.x[C][frame] - geometry.x[B][frame],
+                                    geometry.y[C][frame] - geometry.y[B][frame]);
+
+    const QString angleText =
+        QString("thetaAD=%1 deg\nthetaDC=%2 deg\nthetaBC=%3 deg")
+            .arg(thetaAD, 0, 'f', 1)
+            .arg(thetaDC, 0, 'f', 1)
+            .arg(thetaBC, 0, 'f', 1);
+    painter.drawText(widgetRect.adjusted(10, 24, -10, -10),
+                     Qt::AlignLeft | Qt::AlignTop, angleText);
 }

--- a/student/dcm1/MechanismRenderer.cpp
+++ b/student/dcm1/MechanismRenderer.cpp
@@ -14,6 +14,7 @@
 
 #include "MechanismRenderer.h"
 #include <cmath>
+#include <QCoreApplication>
 #include <QPen>
 
 namespace
@@ -130,8 +131,10 @@ MechanismRenderer::draw(QPainter &painter, const TrajectoryGeometry &geometry,
 
     // value of "i"
     painter.setPen(QPen(Qt::black));
+    const QString frameText =
+        QCoreApplication::translate("MechanismRenderer", "frame=%1/%2");
     painter.drawText(widgetRect, Qt::AlignHCenter | Qt::AlignTop,
-                     QString("frame=%1/%2").arg(frame).arg(nframes));
+                     frameText.arg(frame).arg(nframes));
 
     const auto angleDeg = [](double vx, double vy) {
         const double pi = 3.14159265358979323846;
@@ -146,8 +149,10 @@ MechanismRenderer::draw(QPainter &painter, const TrajectoryGeometry &geometry,
     const double thetaBC = angleDeg(geometry.x[C][frame] - geometry.x[B][frame],
                                     geometry.y[C][frame] - geometry.y[B][frame]);
 
+    const QString angleTextTemplate = QCoreApplication::translate(
+        "MechanismRenderer", "thetaAD=%1 deg\nthetaDC=%2 deg\nthetaBC=%3 deg");
     const QString angleText =
-        QString("thetaAD=%1 deg\nthetaDC=%2 deg\nthetaBC=%3 deg")
+        angleTextTemplate
             .arg(thetaAD, 0, 'f', 1)
             .arg(thetaDC, 0, 'f', 1)
             .arg(thetaBC, 0, 'f', 1);

--- a/student/dcm1/Window.cpp
+++ b/student/dcm1/Window.cpp
@@ -23,7 +23,9 @@
 #include <QDialog>
 #include <QDialogButtonBox>
 #include <QDir>
+#include <QDragEnterEvent>
 #include <QDoubleSpinBox>
+#include <QDropEvent>
 #include <QFile>
 #include <QFileDialog>
 #include <QFileInfo>
@@ -36,6 +38,7 @@
 #include <QJsonParseError>
 #include <QLabel>
 #include <QMenuBar>
+#include <QMimeData>
 #include <QMessageBox>
 #include <QPushButton>
 #include <QSettings>
@@ -45,7 +48,22 @@
 #include <QStatusBar>
 #include <QStandardPaths>
 #include <QTabWidget>
+#include <QUrl>
 #include <QVBoxLayout>
+
+namespace
+{
+int toSliderValue(double value, double minValue, double maxValue)
+{
+    const double ratio = (value - minValue) / (maxValue - minValue);
+    int raw = static_cast<int>(std::lround(ratio * 100.0));
+    if (raw < 0)
+        raw = 0;
+    if (raw > 100)
+        raw = 100;
+    return raw;
+}
+} // namespace
 
 Window::Window(QWidget *parent) : QMainWindow(parent)
 {
@@ -67,6 +85,7 @@ Window::Window(QWidget *parent) : QMainWindow(parent)
 
     QWidget *central = new QWidget(this);
     setCentralWidget(central);
+    setAcceptDrops(true);
 
     viewer = new Barres(central);
     viewer->setMinimumSize(QSize(600, 400));
@@ -132,32 +151,22 @@ Window::Window(QWidget *parent) : QMainWindow(parent)
         return slider;
     };
 
-    auto toSliderValue = [](double value, double minValue, double maxValue) {
-        const double ratio = (value - minValue) / (maxValue - minValue);
-        int raw = static_cast<int>(std::lround(ratio * 100.0));
-        if (raw < 0)
-            raw = 0;
-        if (raw > 100)
-            raw = 100;
-        return raw;
-    };
-
-    QSlider *sliderA1 = addSlider("a1", "Longueur AD (manivelle)", 0.1, 2.0,
-                                  &Barres::set_a1_slot);
-    QSlider *sliderA2 = addSlider("a2", "Longueur DC (bielle)", 2.5, 4.5,
-                                  &Barres::set_a2_slot);
-    QSlider *sliderA3 = addSlider("a3", "Longueur BC (balancier)", 1.0, 3.0,
-                                  &Barres::set_a3_slot);
-    QSlider *sliderXb = addSlider("xb", "Position x du pivot B", 2.0, 4.0,
-                                  &Barres::set_xb_slot);
-    QSlider *sliderYa = addSlider("ya", "Position y du pivot A", 0.5, 2.5,
-                                  &Barres::set_ya_slot);
-    QSlider *sliderL = addSlider("L", "Longueur DP' (point outil)", 4.0, 8.0,
-                                 &Barres::set_L_slot);
-    QSlider *sliderE = addSlider("e", "Offset vertical du film", 0.0, 3.0,
-                                 &Barres::set_e_slot);
-    QSlider *sliderDp = addSlider("dp", "Distance P' -> P", 0.5, 1.5,
-                                  &Barres::set_dp_slot);
+    sliderA1 = addSlider("a1", "Longueur AD (manivelle)", 0.1, 2.0,
+                         &Barres::set_a1_slot);
+    sliderA2 = addSlider("a2", "Longueur DC (bielle)", 2.5, 4.5,
+                         &Barres::set_a2_slot);
+    sliderA3 = addSlider("a3", "Longueur BC (balancier)", 1.0, 3.0,
+                         &Barres::set_a3_slot);
+    sliderXb = addSlider("xb", "Position x du pivot B", 2.0, 4.0,
+                         &Barres::set_xb_slot);
+    sliderYa = addSlider("ya", "Position y du pivot A", 0.5, 2.5,
+                         &Barres::set_ya_slot);
+    sliderL = addSlider("L", "Longueur DP' (point outil)", 4.0, 8.0,
+                        &Barres::set_L_slot);
+    sliderE = addSlider("e", "Offset vertical du film", 0.0, 3.0,
+                        &Barres::set_e_slot);
+    sliderDp = addSlider("dp", "Distance P' -> P", 0.5, 1.5,
+                         &Barres::set_dp_slot);
 
     vbox->addWidget(groupBox);
 
@@ -211,115 +220,17 @@ Window::Window(QWidget *parent) : QMainWindow(parent)
     QAction *actionImport = menuFile->addAction("&Importer parametres...");
     actionImport->setShortcut(QKeySequence::Open);
     QObject::connect(actionImport, &QAction::triggered, this,
-                     [this, sliderA1, sliderA2, sliderA3, sliderXb,
-                      sliderYa, sliderL, sliderE, sliderDp, toSliderValue,
-                      defaultParamsDir, rememberParamsDir]() {
+                     [this, defaultParamsDir, rememberParamsDir]() {
         const QString fileName = QFileDialog::getOpenFileName(
             this, "Importer les parametres", defaultParamsDir(),
             "JSON files (*.json)");
         if (fileName.isEmpty())
             return;
 
+        if (!importParametersFromJsonFile(fileName))
+            return;
+
         rememberParamsDir(fileName);
-
-        QFile file(fileName);
-        if (!file.open(QIODevice::ReadOnly | QIODevice::Text))
-        {
-            QMessageBox::warning(this, "Import impossible",
-                                 "Impossible d'ouvrir le fichier en lecture.");
-            statusBar()->showMessage("Echec de l'import JSON", 2000);
-            return;
-        }
-
-        const QByteArray payload = file.readAll();
-        QJsonParseError parseError;
-        const QJsonDocument doc = QJsonDocument::fromJson(payload, &parseError);
-        if (parseError.error != QJsonParseError::NoError || !doc.isObject())
-        {
-            QMessageBox::warning(this, "Format invalide",
-                                 "Le fichier JSON est invalide.");
-            statusBar()->showMessage("JSON invalide", 2000);
-            return;
-        }
-
-        const QJsonObject root = doc.object();
-        if (root.value("format").toString() != "barres-params")
-        {
-            QMessageBox::warning(this, "Format non reconnu",
-                                 "Le fichier n'est pas un export Barres.");
-            statusBar()->showMessage("Format JSON non reconnu", 2000);
-            return;
-        }
-
-        if (root.value("version").toInt(-1) != 1)
-        {
-            QMessageBox::warning(this, "Version non supportee",
-                                 "Version de fichier non supportee.");
-            statusBar()->showMessage("Version JSON non supportee", 2000);
-            return;
-        }
-
-        const QJsonValue paramsValue = root.value("params");
-        if (!paramsValue.isObject())
-        {
-            QMessageBox::warning(this, "Fichier incomplet",
-                                 "Objet 'params' manquant.");
-            statusBar()->showMessage("Objet params manquant", 2000);
-            return;
-        }
-
-        const QJsonObject paramsObj = paramsValue.toObject();
-        auto readParam = [&](const char *name, double minValue, double maxValue,
-                             bool &ok) {
-            const QJsonValue value = paramsObj.value(name);
-            if (!value.isDouble())
-            {
-                ok = false;
-                return 0.0;
-            }
-
-            const double v = value.toDouble();
-            if (!std::isfinite(v) || v < minValue || v > maxValue)
-            {
-                ok = false;
-                return 0.0;
-            }
-
-            return v;
-        };
-
-        bool ok = true;
-        MechanismParameters p;
-        p.a1 = readParam("a1", 0.1, 2.0, ok);
-        p.a2 = readParam("a2", 2.5, 4.5, ok);
-        p.a3 = readParam("a3", 1.0, 3.0, ok);
-        p.xb = readParam("xb", 2.0, 4.0, ok);
-        p.ya = readParam("ya", 0.5, 2.5, ok);
-        p.L = readParam("L", 4.0, 8.0, ok);
-        p.e = readParam("e", 0.0, 3.0, ok);
-        p.dp = readParam("dp", 0.5, 1.5, ok);
-
-        if (!ok)
-        {
-            QMessageBox::warning(this, "Parametres invalides",
-                                 "Un ou plusieurs parametres sont manquants ou hors bornes.");
-            statusBar()->showMessage("Parametres JSON invalides", 2000);
-            return;
-        }
-
-        viewer->applyParameters(p);
-
-        // Keep UI controls in sync with imported parameters.
-        sliderA1->setValue(toSliderValue(p.a1, 0.1, 2.0));
-        sliderA2->setValue(toSliderValue(p.a2, 2.5, 4.5));
-        sliderA3->setValue(toSliderValue(p.a3, 1.0, 3.0));
-        sliderXb->setValue(toSliderValue(p.xb, 2.0, 4.0));
-        sliderYa->setValue(toSliderValue(p.ya, 0.5, 2.5));
-        sliderL->setValue(toSliderValue(p.L, 4.0, 8.0));
-        sliderE->setValue(toSliderValue(p.e, 0.0, 3.0));
-        sliderDp->setValue(toSliderValue(p.dp, 0.5, 1.5));
-
-        statusBar()->showMessage("Parametres importes depuis JSON", 2000);
     });
 
     QAction *actionExport = menuFile->addAction("&Exporter parametres...");
@@ -645,4 +556,162 @@ Window::closeEvent(QCloseEvent *event)
     QSettings settings;
     settings.setValue("window/size", size());
     QMainWindow::closeEvent(event);
+}
+
+void
+Window::dragEnterEvent(QDragEnterEvent *event)
+{
+    const QMimeData *mimeData = event->mimeData();
+    if (!mimeData || !mimeData->hasUrls())
+        return;
+
+    const QList<QUrl> urls = mimeData->urls();
+    for (const QUrl &url : urls)
+    {
+        if (!url.isLocalFile())
+            continue;
+
+        const QString localFile = url.toLocalFile();
+        if (QFileInfo(localFile).suffix().compare("json", Qt::CaseInsensitive) == 0)
+        {
+            event->acceptProposedAction();
+            return;
+        }
+    }
+}
+
+void
+Window::dropEvent(QDropEvent *event)
+{
+    const QMimeData *mimeData = event->mimeData();
+    if (!mimeData || !mimeData->hasUrls())
+        return;
+
+    const QList<QUrl> urls = mimeData->urls();
+    for (const QUrl &url : urls)
+    {
+        if (!url.isLocalFile())
+            continue;
+
+        const QString localFile = url.toLocalFile();
+        if (QFileInfo(localFile).suffix().compare("json", Qt::CaseInsensitive) != 0)
+            continue;
+
+        if (importParametersFromJsonFile(localFile))
+        {
+            QSettings settings;
+            settings.setValue("io/lastParamsDir", QFileInfo(localFile).absolutePath());
+            event->acceptProposedAction();
+        }
+        return;
+    }
+
+    statusBar()->showMessage("Deposer un fichier .json valide", 2000);
+}
+
+bool
+Window::importParametersFromJsonFile(const QString &fileName)
+{
+    QFile file(fileName);
+    if (!file.open(QIODevice::ReadOnly | QIODevice::Text))
+    {
+        QMessageBox::warning(this, "Import impossible",
+                             "Impossible d'ouvrir le fichier en lecture.");
+        statusBar()->showMessage("Echec de l'import JSON", 2000);
+        return false;
+    }
+
+    const QByteArray payload = file.readAll();
+    QJsonParseError parseError;
+    const QJsonDocument doc = QJsonDocument::fromJson(payload, &parseError);
+    if (parseError.error != QJsonParseError::NoError || !doc.isObject())
+    {
+        QMessageBox::warning(this, "Format invalide",
+                             "Le fichier JSON est invalide.");
+        statusBar()->showMessage("JSON invalide", 2000);
+        return false;
+    }
+
+    const QJsonObject root = doc.object();
+    if (root.value("format").toString() != "barres-params")
+    {
+        QMessageBox::warning(this, "Format non reconnu",
+                             "Le fichier n'est pas un export Barres.");
+        statusBar()->showMessage("Format JSON non reconnu", 2000);
+        return false;
+    }
+
+    if (root.value("version").toInt(-1) != 1)
+    {
+        QMessageBox::warning(this, "Version non supportee",
+                             "Version de fichier non supportee.");
+        statusBar()->showMessage("Version JSON non supportee", 2000);
+        return false;
+    }
+
+    const QJsonValue paramsValue = root.value("params");
+    if (!paramsValue.isObject())
+    {
+        QMessageBox::warning(this, "Fichier incomplet",
+                             "Objet 'params' manquant.");
+        statusBar()->showMessage("Objet params manquant", 2000);
+        return false;
+    }
+
+    const QJsonObject paramsObj = paramsValue.toObject();
+    auto readParam = [&](const char *name, double minValue, double maxValue,
+                         bool &ok) {
+        const QJsonValue value = paramsObj.value(name);
+        if (!value.isDouble())
+        {
+            ok = false;
+            return 0.0;
+        }
+
+        const double v = value.toDouble();
+        if (!std::isfinite(v) || v < minValue || v > maxValue)
+        {
+            ok = false;
+            return 0.0;
+        }
+
+        return v;
+    };
+
+    bool ok = true;
+    MechanismParameters p;
+    p.a1 = readParam("a1", 0.1, 2.0, ok);
+    p.a2 = readParam("a2", 2.5, 4.5, ok);
+    p.a3 = readParam("a3", 1.0, 3.0, ok);
+    p.xb = readParam("xb", 2.0, 4.0, ok);
+    p.ya = readParam("ya", 0.5, 2.5, ok);
+    p.L = readParam("L", 4.0, 8.0, ok);
+    p.e = readParam("e", 0.0, 3.0, ok);
+    p.dp = readParam("dp", 0.5, 1.5, ok);
+
+    if (!ok)
+    {
+        QMessageBox::warning(this, "Parametres invalides",
+                             "Un ou plusieurs parametres sont manquants ou hors bornes.");
+        statusBar()->showMessage("Parametres JSON invalides", 2000);
+        return false;
+    }
+
+    viewer->applyParameters(p);
+    syncSlidersFromParameters(p);
+    statusBar()->showMessage("Parametres importes depuis JSON", 2000);
+    return true;
+}
+
+void
+Window::syncSlidersFromParameters(const MechanismParameters &p)
+{
+    sliderA1->setValue(toSliderValue(p.a1, 0.1, 2.0));
+    sliderA2->setValue(toSliderValue(p.a2, 2.5, 4.5));
+    sliderA3->setValue(toSliderValue(p.a3, 1.0, 3.0));
+    sliderXb->setValue(toSliderValue(p.xb, 2.0, 4.0));
+    sliderYa->setValue(toSliderValue(p.ya, 0.5, 2.5));
+    sliderL->setValue(toSliderValue(p.L, 4.0, 8.0));
+    sliderE->setValue(toSliderValue(p.e, 0.0, 3.0));
+    sliderDp->setValue(toSliderValue(p.dp, 0.5, 1.5));
 }

--- a/student/dcm1/Window.cpp
+++ b/student/dcm1/Window.cpp
@@ -222,8 +222,8 @@ Window::Window(QWidget *parent) : QMainWindow(parent)
     QObject::connect(actionImport, &QAction::triggered, this,
                      [this, defaultParamsDir, rememberParamsDir]() {
         const QString fileName = QFileDialog::getOpenFileName(
-            this, "Importer les parametres", defaultParamsDir(),
-            "JSON files (*.json)");
+            this, tr("Importer les parametres"), defaultParamsDir(),
+            tr("JSON files (*.json)"));
         if (fileName.isEmpty())
             return;
 
@@ -240,8 +240,8 @@ Window::Window(QWidget *parent) : QMainWindow(parent)
         const QString defaultFile =
             QDir(defaultParamsDir()).filePath("barres-params.json");
         const QString fileName = QFileDialog::getSaveFileName(
-            this, "Exporter les parametres", defaultFile,
-            "JSON files (*.json)");
+            this, tr("Exporter les parametres"), defaultFile,
+            tr("JSON files (*.json)"));
         if (fileName.isEmpty())
             return;
 
@@ -268,9 +268,9 @@ Window::Window(QWidget *parent) : QMainWindow(parent)
         QFile file(fileName);
         if (!file.open(QIODevice::WriteOnly | QIODevice::Text))
         {
-            QMessageBox::warning(this, "Export impossible",
-                                 "Impossible d'ouvrir le fichier pour ecriture.");
-            statusBar()->showMessage("Echec de l'export JSON", 2000);
+            QMessageBox::warning(this, tr("Export impossible"),
+                                 tr("Impossible d'ouvrir le fichier pour ecriture."));
+            statusBar()->showMessage(tr("Echec de l'export JSON"), 2000);
             return;
         }
 
@@ -278,13 +278,13 @@ Window::Window(QWidget *parent) : QMainWindow(parent)
         const qint64 written = file.write(payload);
         if (written != payload.size())
         {
-            QMessageBox::warning(this, "Export incomplet",
-                                 "Le fichier n'a pas ete ecrit completement.");
-            statusBar()->showMessage("Export JSON incomplet", 2000);
+            QMessageBox::warning(this, tr("Export incomplet"),
+                                 tr("Le fichier n'a pas ete ecrit completement."));
+            statusBar()->showMessage(tr("Export JSON incomplet"), 2000);
             return;
         }
 
-        statusBar()->showMessage("Parametres exportes en JSON", 2000);
+        statusBar()->showMessage(tr("Parametres exportes en JSON"), 2000);
     });
 
     menuFile->addSeparator();
@@ -295,7 +295,7 @@ Window::Window(QWidget *parent) : QMainWindow(parent)
 
     auto openRenderStyleDialog = [this]() {
         QDialog dialog(this);
-        dialog.setWindowTitle("Parametres de dessin");
+        dialog.setWindowTitle(tr("Parametres de dessin"));
         dialog.setMinimumWidth(460);
 
         QVBoxLayout *rootLayout = new QVBoxLayout(&dialog);
@@ -306,7 +306,7 @@ Window::Window(QWidget *parent) : QMainWindow(parent)
 
         QWidget *tabLines = new QWidget(&dialog);
         QFormLayout *linesLayout = new QFormLayout(tabLines);
-        tabs->addTab(tabLines, "Traits");
+        tabs->addTab(tabLines, tr("Traits"));
 
         auto makeDouble = [](double minV, double maxV, double value,
                              int decimals = 2) {
@@ -335,15 +335,15 @@ Window::Window(QWidget *parent) : QMainWindow(parent)
         QDoubleSpinBox *sbFilmExtension =
             makeDouble(0.0, 50.0, current.filmExtension, 2);
 
-        linesLayout->addRow("Epaisseur liens", sbLinkPenWidth);
-        linesLayout->addRow("Epaisseur trajectoire P", sbTrajPWidth);
-        linesLayout->addRow("Epaisseur trajectoire D", sbTrajDWidth);
-        linesLayout->addRow("Demi-longueur sol", sbGroundHalfLen);
-        linesLayout->addRow("Longueur film", sbFilmExtension);
+        linesLayout->addRow(tr("Epaisseur liens"), sbLinkPenWidth);
+        linesLayout->addRow(tr("Epaisseur trajectoire P"), sbTrajPWidth);
+        linesLayout->addRow(tr("Epaisseur trajectoire D"), sbTrajDWidth);
+        linesLayout->addRow(tr("Demi-longueur sol"), sbGroundHalfLen);
+        linesLayout->addRow(tr("Longueur film"), sbFilmExtension);
 
         QWidget *tabLabels = new QWidget(&dialog);
         QFormLayout *labelsLayout = new QFormLayout(tabLabels);
-        tabs->addTab(tabLabels, "Labels");
+        tabs->addTab(tabLabels, tr("Labels"));
 
         QSpinBox *sbLabelFontSize =
             makeInt(6, 48, current.labelFontSize);
@@ -352,20 +352,20 @@ Window::Window(QWidget *parent) : QMainWindow(parent)
         QSpinBox *sbLabelOffsetY =
             makeInt(-50, 50, current.labelOffsetY);
 
-        labelsLayout->addRow("Taille police", sbLabelFontSize);
-        labelsLayout->addRow("Offset X", sbLabelOffsetX);
-        labelsLayout->addRow("Offset Y", sbLabelOffsetY);
+        labelsLayout->addRow(tr("Taille police"), sbLabelFontSize);
+        labelsLayout->addRow(tr("Offset X"), sbLabelOffsetX);
+        labelsLayout->addRow(tr("Offset Y"), sbLabelOffsetY);
 
         QWidget *tabColors = new QWidget(&dialog);
         QFormLayout *colorsLayout = new QFormLayout(tabColors);
-        tabs->addTab(tabColors, "Couleurs");
+        tabs->addTab(tabColors, tr("Couleurs"));
 
         QColor mainColor = current.mainColor;
         QColor trajectoryPColor = current.trajectoryPColor;
         QColor trajectoryDColor = current.trajectoryDColor;
 
-        auto makeColorButton = []() {
-            QPushButton *button = new QPushButton("Choisir...");
+        auto makeColorButton = [this]() {
+            QPushButton *button = new QPushButton(tr("Choisir..."));
             button->setMinimumWidth(120);
             return button;
         };
@@ -399,15 +399,15 @@ Window::Window(QWidget *parent) : QMainWindow(parent)
         QPushButton *btnTrajectoryPColor = makeColorButton();
         QPushButton *btnTrajectoryDColor = makeColorButton();
 
-        wireColorButton(btnMainColor, &mainColor, "Couleur principale");
+        wireColorButton(btnMainColor, &mainColor, tr("Couleur principale"));
         wireColorButton(btnTrajectoryPColor, &trajectoryPColor,
-                        "Couleur trajectoire P");
+                tr("Couleur trajectoire P"));
         wireColorButton(btnTrajectoryDColor, &trajectoryDColor,
-                        "Couleur trajectoire D");
+                tr("Couleur trajectoire D"));
 
-        colorsLayout->addRow("Couleur principale", btnMainColor);
-        colorsLayout->addRow("Trajectoire P", btnTrajectoryPColor);
-        colorsLayout->addRow("Trajectoire D", btnTrajectoryDColor);
+        colorsLayout->addRow(tr("Couleur principale"), btnMainColor);
+        colorsLayout->addRow(tr("Trajectoire P"), btnTrajectoryPColor);
+        colorsLayout->addRow(tr("Trajectoire D"), btnTrajectoryDColor);
 
         auto collectStyle = [&]() {
             RenderStyleSettings s;
@@ -431,12 +431,12 @@ Window::Window(QWidget *parent) : QMainWindow(parent)
                                  QDialogButtonBox::Apply,
                                  &dialog);
         QPushButton *resetButton =
-            buttonBox->addButton("Reinitialiser", QDialogButtonBox::ResetRole);
+            buttonBox->addButton(tr("Reinitialiser"), QDialogButtonBox::ResetRole);
         rootLayout->addWidget(buttonBox);
 
         auto applyStyle = [&]() {
             viewer->applyRenderStyle(collectStyle());
-            statusBar()->showMessage("Style de dessin applique", 1500);
+            statusBar()->showMessage(tr("Style de dessin applique"), 1500);
         };
 
         QObject::connect(buttonBox->button(QDialogButtonBox::Apply),
@@ -494,31 +494,31 @@ Window::Window(QWidget *parent) : QMainWindow(parent)
     QObject::connect(viewer, &Barres::animationStarted, this, [this]() {
         actionStart->setEnabled(false);
         actionStop->setEnabled(true);
-        statusBar()->showMessage("Animation demarree");
+        statusBar()->showMessage(tr("Animation demarree"));
     });
     QObject::connect(viewer, &Barres::animationStopped, this, [this]() {
         actionStart->setEnabled(true);
         actionStop->setEnabled(false);
-        statusBar()->showMessage("Animation arretee");
+        statusBar()->showMessage(tr("Animation arretee"));
     });
 
     QMenu *menuHelp = menuBar()->addMenu(tr("&Aide"));
     QAction *actionAbout = menuHelp->addAction(tr("&A propos"));
     QObject::connect(actionAbout, &QAction::triggered, this, [this]() {
-        QMessageBox::about(this, "A propos",
-                           "Barres\n"
-                           "Simulation d'un mecanisme planar.\n"
-                           "Projet Qt Widgets / C++.\n\n"
-                           "Commandes:\n"
-                           "- Menu Fichier > Quitter\n"
-                           "- Menu Animation > Demarrer / Arreter\n"
-                           "- Sliders: reglage des parametres geometriques\n\n"
-                           "Raccourcis clavier:\n"
-                           "- Espace : demarrer / arreter l'animation\n"
-                           "- R : reinitialiser a la frame 0\n"
-                           "- Fleche droite : frame suivante\n"
-                           "- Fleche gauche : frame precedente");
-        statusBar()->showMessage("Affichage de la boite A propos", 2000);
+        QMessageBox::about(this, tr("A propos"),
+                           tr("Barres\n"
+                              "Simulation d'un mecanisme planar.\n"
+                              "Projet Qt Widgets / C++.\n\n"
+                              "Commandes:\n"
+                              "- Menu Fichier > Quitter\n"
+                              "- Menu Animation > Demarrer / Arreter\n"
+                              "- Sliders: reglage des parametres geometriques\n\n"
+                              "Raccourcis clavier:\n"
+                              "- Espace : demarrer / arreter l'animation\n"
+                              "- R : reinitialiser a la frame 0\n"
+                              "- Fleche droite : frame suivante\n"
+                              "- Fleche gauche : frame precedente"));
+        statusBar()->showMessage(tr("Affichage de la boite A propos"), 2000);
     });
 
     QShortcut *shortcutToggle = new QShortcut(QKeySequence(Qt::Key_Space), this);
@@ -530,24 +530,24 @@ Window::Window(QWidget *parent) : QMainWindow(parent)
     shortcutReset->setContext(Qt::ApplicationShortcut);
     QObject::connect(shortcutReset, &QShortcut::activated, this, [this]() {
         viewer->resetAnimation();
-        statusBar()->showMessage("Animation reinitialisee", 1500);
+        statusBar()->showMessage(tr("Animation reinitialisee"), 1500);
     });
 
     QShortcut *shortcutStepPrev = new QShortcut(QKeySequence(Qt::Key_Left), this);
     shortcutStepPrev->setContext(Qt::ApplicationShortcut);
     QObject::connect(shortcutStepPrev, &QShortcut::activated, this, [this]() {
         viewer->stepBackward();
-        statusBar()->showMessage("Frame precedente", 1000);
+        statusBar()->showMessage(tr("Frame precedente"), 1000);
     });
 
     QShortcut *shortcutStepNext = new QShortcut(QKeySequence(Qt::Key_Right), this);
     shortcutStepNext->setContext(Qt::ApplicationShortcut);
     QObject::connect(shortcutStepNext, &QShortcut::activated, this, [this]() {
         viewer->stepForward();
-        statusBar()->showMessage("Frame suivante", 1000);
+        statusBar()->showMessage(tr("Frame suivante"), 1000);
     });
 
-    statusBar()->showMessage("Pret");
+    statusBar()->showMessage(tr("Pret"));
 }
 
 void
@@ -606,7 +606,7 @@ Window::dropEvent(QDropEvent *event)
         return;
     }
 
-    statusBar()->showMessage("Deposer un fichier .json valide", 2000);
+    statusBar()->showMessage(tr("Deposer un fichier .json valide"), 2000);
 }
 
 bool
@@ -615,9 +615,9 @@ Window::importParametersFromJsonFile(const QString &fileName)
     QFile file(fileName);
     if (!file.open(QIODevice::ReadOnly | QIODevice::Text))
     {
-        QMessageBox::warning(this, "Import impossible",
-                             "Impossible d'ouvrir le fichier en lecture.");
-        statusBar()->showMessage("Echec de l'import JSON", 2000);
+        QMessageBox::warning(this, tr("Import impossible"),
+                             tr("Impossible d'ouvrir le fichier en lecture."));
+        statusBar()->showMessage(tr("Echec de l'import JSON"), 2000);
         return false;
     }
 
@@ -626,35 +626,35 @@ Window::importParametersFromJsonFile(const QString &fileName)
     const QJsonDocument doc = QJsonDocument::fromJson(payload, &parseError);
     if (parseError.error != QJsonParseError::NoError || !doc.isObject())
     {
-        QMessageBox::warning(this, "Format invalide",
-                             "Le fichier JSON est invalide.");
-        statusBar()->showMessage("JSON invalide", 2000);
+        QMessageBox::warning(this, tr("Format invalide"),
+                             tr("Le fichier JSON est invalide."));
+        statusBar()->showMessage(tr("JSON invalide"), 2000);
         return false;
     }
 
     const QJsonObject root = doc.object();
     if (root.value("format").toString() != "barres-params")
     {
-        QMessageBox::warning(this, "Format non reconnu",
-                             "Le fichier n'est pas un export Barres.");
-        statusBar()->showMessage("Format JSON non reconnu", 2000);
+        QMessageBox::warning(this, tr("Format non reconnu"),
+                             tr("Le fichier n'est pas un export Barres."));
+        statusBar()->showMessage(tr("Format JSON non reconnu"), 2000);
         return false;
     }
 
     if (root.value("version").toInt(-1) != 1)
     {
-        QMessageBox::warning(this, "Version non supportee",
-                             "Version de fichier non supportee.");
-        statusBar()->showMessage("Version JSON non supportee", 2000);
+        QMessageBox::warning(this, tr("Version non supportee"),
+                             tr("Version de fichier non supportee."));
+        statusBar()->showMessage(tr("Version JSON non supportee"), 2000);
         return false;
     }
 
     const QJsonValue paramsValue = root.value("params");
     if (!paramsValue.isObject())
     {
-        QMessageBox::warning(this, "Fichier incomplet",
-                             "Objet 'params' manquant.");
-        statusBar()->showMessage("Objet params manquant", 2000);
+        QMessageBox::warning(this, tr("Fichier incomplet"),
+                             tr("Objet 'params' manquant."));
+        statusBar()->showMessage(tr("Objet params manquant"), 2000);
         return false;
     }
 
@@ -691,15 +691,15 @@ Window::importParametersFromJsonFile(const QString &fileName)
 
     if (!ok)
     {
-        QMessageBox::warning(this, "Parametres invalides",
-                             "Un ou plusieurs parametres sont manquants ou hors bornes.");
-        statusBar()->showMessage("Parametres JSON invalides", 2000);
+        QMessageBox::warning(this, tr("Parametres invalides"),
+                             tr("Un ou plusieurs parametres sont manquants ou hors bornes."));
+        statusBar()->showMessage(tr("Parametres JSON invalides"), 2000);
         return false;
     }
 
     viewer->applyParameters(p);
     syncSlidersFromParameters(p);
-    statusBar()->showMessage("Parametres importes depuis JSON", 2000);
+    statusBar()->showMessage(tr("Parametres importes depuis JSON"), 2000);
     return true;
 }
 

--- a/student/dcm1/Window.cpp
+++ b/student/dcm1/Window.cpp
@@ -151,21 +151,21 @@ Window::Window(QWidget *parent) : QMainWindow(parent)
         return slider;
     };
 
-    sliderA1 = addSlider("a1", "Longueur AD (manivelle)", 0.1, 2.0,
+    sliderA1 = addSlider("a1", tr("Longueur AD (manivelle)"), 0.1, 2.0,
                          &Barres::set_a1_slot);
-    sliderA2 = addSlider("a2", "Longueur DC (bielle)", 2.5, 4.5,
+    sliderA2 = addSlider("a2", tr("Longueur DC (bielle)"), 2.5, 4.5,
                          &Barres::set_a2_slot);
-    sliderA3 = addSlider("a3", "Longueur BC (balancier)", 1.0, 3.0,
+    sliderA3 = addSlider("a3", tr("Longueur BC (balancier)"), 1.0, 3.0,
                          &Barres::set_a3_slot);
-    sliderXb = addSlider("xb", "Position x du pivot B", 2.0, 4.0,
+    sliderXb = addSlider("xb", tr("Position x du pivot B"), 2.0, 4.0,
                          &Barres::set_xb_slot);
-    sliderYa = addSlider("ya", "Position y du pivot A", 0.5, 2.5,
+    sliderYa = addSlider("ya", tr("Position y du pivot A"), 0.5, 2.5,
                          &Barres::set_ya_slot);
-    sliderL = addSlider("L", "Longueur DP' (point outil)", 4.0, 8.0,
+    sliderL = addSlider("L", tr("Longueur DP' (point outil)"), 4.0, 8.0,
                         &Barres::set_L_slot);
-    sliderE = addSlider("e", "Offset vertical du film", 0.0, 3.0,
+    sliderE = addSlider("e", tr("Offset vertical du film"), 0.0, 3.0,
                         &Barres::set_e_slot);
-    sliderDp = addSlider("dp", "Distance P' -> P", 0.5, 1.5,
+    sliderDp = addSlider("dp", tr("Distance P' -> P"), 0.5, 1.5,
                          &Barres::set_dp_slot);
 
     vbox->addWidget(groupBox);
@@ -177,8 +177,8 @@ Window::Window(QWidget *parent) : QMainWindow(parent)
     QSpinBox *speedMsSpin = new QSpinBox();
     speedMsSpin->setRange(5, 200);
     speedMsSpin->setSingleStep(5);
-    speedMsSpin->setSuffix(" ms/frame");
-    speedMsSpin->setToolTip("Intervalle entre deux frames d'animation");
+    speedMsSpin->setSuffix(tr(" ms/frame"));
+    speedMsSpin->setToolTip(tr("Intervalle entre deux frames d'animation"));
     speedMsSpin->setValue(viewer->currentAnimationIntervalMs());
     animLayout->addRow(tr("Vitesse"), speedMsSpin);
 
@@ -187,7 +187,7 @@ Window::Window(QWidget *parent) : QMainWindow(parent)
     QObject::connect(speedMsSpin, QOverload<int>::of(&QSpinBox::valueChanged),
                      this, [this](int intervalMs) {
                          statusBar()->showMessage(
-                             QString("Vitesse animation: %1 ms/frame")
+                             tr("Vitesse animation: %1 ms/frame")
                                  .arg(intervalMs),
                              1200);
                      });

--- a/student/dcm1/Window.cpp
+++ b/student/dcm1/Window.cpp
@@ -17,6 +17,7 @@
 #include <cmath>
 #include <QAction>
 #include <QApplication>
+#include <QCloseEvent>
 #include <QColorDialog>
 #include <QDateTime>
 #include <QDialog>
@@ -49,8 +50,20 @@
 Window::Window(QWidget *parent) : QMainWindow(parent)
 {
     this->setWindowTitle("Barres");
-    this->resize(800, 600);
     this->setMinimumSize(900, 580);
+
+    {
+        QSettings settings;
+        const QSize defaultSize(1000, 650);
+        QSize savedSize = settings.value("window/size", defaultSize).toSize();
+        if (!savedSize.isValid())
+            savedSize = defaultSize;
+        if (savedSize.width() < minimumWidth())
+            savedSize.setWidth(minimumWidth());
+        if (savedSize.height() < minimumHeight())
+            savedSize.setHeight(minimumHeight());
+        this->resize(savedSize);
+    }
 
     QWidget *central = new QWidget(this);
     setCentralWidget(central);
@@ -147,6 +160,30 @@ Window::Window(QWidget *parent) : QMainWindow(parent)
                                   &Barres::set_dp_slot);
 
     vbox->addWidget(groupBox);
+
+    QGroupBox *animGroup = new QGroupBox("Animation");
+    QFormLayout *animLayout = new QFormLayout();
+    animGroup->setLayout(animLayout);
+
+    QSpinBox *speedMsSpin = new QSpinBox();
+    speedMsSpin->setRange(5, 200);
+    speedMsSpin->setSingleStep(5);
+    speedMsSpin->setSuffix(" ms/frame");
+    speedMsSpin->setToolTip("Intervalle entre deux frames d'animation");
+    speedMsSpin->setValue(viewer->currentAnimationIntervalMs());
+    animLayout->addRow("Vitesse", speedMsSpin);
+
+    QObject::connect(speedMsSpin, QOverload<int>::of(&QSpinBox::valueChanged),
+                     viewer, &Barres::setAnimationIntervalMs);
+    QObject::connect(speedMsSpin, QOverload<int>::of(&QSpinBox::valueChanged),
+                     this, [this](int intervalMs) {
+                         statusBar()->showMessage(
+                             QString("Vitesse animation: %1 ms/frame")
+                                 .arg(intervalMs),
+                             1200);
+                     });
+
+    vbox->addWidget(animGroup);
     vbox->addStretch(1);
 
     // -- menu bar
@@ -600,4 +637,12 @@ Window::Window(QWidget *parent) : QMainWindow(parent)
     });
 
     statusBar()->showMessage("Pret");
+}
+
+void
+Window::closeEvent(QCloseEvent *event)
+{
+    QSettings settings;
+    settings.setValue("window/size", size());
+    QMainWindow::closeEvent(event);
 }

--- a/student/dcm1/Window.cpp
+++ b/student/dcm1/Window.cpp
@@ -16,6 +16,7 @@
 #include "Barres.h"
 #include <cmath>
 #include <QAction>
+#include <QActionGroup>
 #include <QApplication>
 #include <QCloseEvent>
 #include <QColorDialog>
@@ -480,6 +481,44 @@ Window::Window(QWidget *parent) : QMainWindow(parent)
         menuView->addAction(tr("Parametres de dessin..."));
     QObject::connect(actionRenderStyle, &QAction::triggered,
                      this, openRenderStyleDialog);
+
+    menuView->addSeparator();
+    QMenu *menuLanguage = menuView->addMenu(tr("Langue"));
+    QActionGroup *languageGroup = new QActionGroup(this);
+    languageGroup->setExclusive(true);
+
+    QAction *actionLangFr = menuLanguage->addAction(tr("Francais"));
+    actionLangFr->setCheckable(true);
+    languageGroup->addAction(actionLangFr);
+
+    QAction *actionLangEn = menuLanguage->addAction(tr("Anglais"));
+    actionLangEn->setCheckable(true);
+    languageGroup->addAction(actionLangEn);
+
+    const QString currentLanguage =
+        QSettings().value("ui/language", "fr").toString().toLower();
+    if (currentLanguage == "en")
+        actionLangEn->setChecked(true);
+    else
+        actionLangFr->setChecked(true);
+
+    auto setLanguage = [this](const QString &languageCode) {
+        QSettings settings;
+        const QString oldLanguage =
+            settings.value("ui/language", "fr").toString().toLower();
+        if (oldLanguage == languageCode)
+            return;
+
+        settings.setValue("ui/language", languageCode);
+        QMessageBox::information(this, tr("Langue"),
+                                 tr("La langue sera appliquee au prochain demarrage."));
+        statusBar()->showMessage(tr("Preference de langue sauvegardee"), 2000);
+    };
+
+    QObject::connect(actionLangFr, &QAction::triggered, this,
+                     [setLanguage]() { setLanguage("fr"); });
+    QObject::connect(actionLangEn, &QAction::triggered, this,
+                     [setLanguage]() { setLanguage("en"); });
 
     QMenu *menuAnimation = menuBar()->addMenu(tr("&Animation"));
     actionStart = menuAnimation->addAction(tr("&Démarrer"));

--- a/student/dcm1/Window.cpp
+++ b/student/dcm1/Window.cpp
@@ -67,7 +67,7 @@ int toSliderValue(double value, double minValue, double maxValue)
 
 Window::Window(QWidget *parent) : QMainWindow(parent)
 {
-    this->setWindowTitle("Barres");
+    this->setWindowTitle(tr("Barres"));
     this->setMinimumSize(900, 580);
 
     {
@@ -105,7 +105,7 @@ Window::Window(QWidget *parent) : QMainWindow(parent)
 
     QVBoxLayout *vbox = new QVBoxLayout(pan);
 
-    QGroupBox *groupBox = new QGroupBox("Parameters");
+    QGroupBox *groupBox = new QGroupBox(tr("Parameters"));
     QFormLayout *formLayout = new QFormLayout();
     formLayout->setHorizontalSpacing(10);
     formLayout->setLabelAlignment(Qt::AlignRight | Qt::AlignVCenter);
@@ -170,7 +170,7 @@ Window::Window(QWidget *parent) : QMainWindow(parent)
 
     vbox->addWidget(groupBox);
 
-    QGroupBox *animGroup = new QGroupBox("Animation");
+    QGroupBox *animGroup = new QGroupBox(tr("Animation"));
     QFormLayout *animLayout = new QFormLayout();
     animGroup->setLayout(animLayout);
 
@@ -180,7 +180,7 @@ Window::Window(QWidget *parent) : QMainWindow(parent)
     speedMsSpin->setSuffix(" ms/frame");
     speedMsSpin->setToolTip("Intervalle entre deux frames d'animation");
     speedMsSpin->setValue(viewer->currentAnimationIntervalMs());
-    animLayout->addRow("Vitesse", speedMsSpin);
+    animLayout->addRow(tr("Vitesse"), speedMsSpin);
 
     QObject::connect(speedMsSpin, QOverload<int>::of(&QSpinBox::valueChanged),
                      viewer, &Barres::setAnimationIntervalMs);
@@ -196,7 +196,7 @@ Window::Window(QWidget *parent) : QMainWindow(parent)
     vbox->addStretch(1);
 
     // -- menu bar
-    QMenu *menuFile = menuBar()->addMenu("&Fichier");
+    QMenu *menuFile = menuBar()->addMenu(tr("&Fichier"));
 
     auto defaultParamsDir = []() {
         QSettings settings;
@@ -217,7 +217,7 @@ Window::Window(QWidget *parent) : QMainWindow(parent)
         settings.setValue("io/lastParamsDir", QFileInfo(fileName).absolutePath());
     };
 
-    QAction *actionImport = menuFile->addAction("&Importer parametres...");
+    QAction *actionImport = menuFile->addAction(tr("&Importer parametres..."));
     actionImport->setShortcut(QKeySequence::Open);
     QObject::connect(actionImport, &QAction::triggered, this,
                      [this, defaultParamsDir, rememberParamsDir]() {
@@ -233,7 +233,7 @@ Window::Window(QWidget *parent) : QMainWindow(parent)
         rememberParamsDir(fileName);
     });
 
-    QAction *actionExport = menuFile->addAction("&Exporter parametres...");
+    QAction *actionExport = menuFile->addAction(tr("&Exporter parametres..."));
     actionExport->setShortcut(QKeySequence::Save);
     QObject::connect(actionExport, &QAction::triggered, this,
                      [this, defaultParamsDir, rememberParamsDir]() {
@@ -288,7 +288,7 @@ Window::Window(QWidget *parent) : QMainWindow(parent)
     });
 
     menuFile->addSeparator();
-    QAction *actionQuit = menuFile->addAction("&Quitter");
+    QAction *actionQuit = menuFile->addAction(tr("&Quitter"));
     actionQuit->setShortcut(QKeySequence::Quit);
     QObject::connect(actionQuit, &QAction::triggered,
                      qApp, &QApplication::quit);
@@ -470,20 +470,20 @@ Window::Window(QWidget *parent) : QMainWindow(parent)
         dialog.exec();
     };
 
-    QMenu *menuView = menuBar()->addMenu("&Affichage");
-    QAction *actionResetView = menuView->addAction("Réinitialiser la vue");
+    QMenu *menuView = menuBar()->addMenu(tr("&Affichage"));
+    QAction *actionResetView = menuView->addAction(tr("Réinitialiser la vue"));
     actionResetView->setShortcut(Qt::Key_H);
     QObject::connect(actionResetView, &QAction::triggered,
                      viewer, &Barres::resetView);
     menuView->addSeparator();
     QAction *actionRenderStyle =
-        menuView->addAction("Parametres de dessin...");
+        menuView->addAction(tr("Parametres de dessin..."));
     QObject::connect(actionRenderStyle, &QAction::triggered,
                      this, openRenderStyleDialog);
 
-    QMenu *menuAnimation = menuBar()->addMenu("&Animation");
-    actionStart = menuAnimation->addAction("&Démarrer");
-    actionStop  = menuAnimation->addAction("&Arrêter");
+    QMenu *menuAnimation = menuBar()->addMenu(tr("&Animation"));
+    actionStart = menuAnimation->addAction(tr("&Démarrer"));
+    actionStop  = menuAnimation->addAction(tr("&Arrêter"));
     actionStart->setEnabled(true);
     actionStop->setEnabled(false);
 
@@ -502,8 +502,8 @@ Window::Window(QWidget *parent) : QMainWindow(parent)
         statusBar()->showMessage("Animation arretee");
     });
 
-    QMenu *menuHelp = menuBar()->addMenu("&Aide");
-    QAction *actionAbout = menuHelp->addAction("&A propos");
+    QMenu *menuHelp = menuBar()->addMenu(tr("&Aide"));
+    QAction *actionAbout = menuHelp->addAction(tr("&A propos"));
     QObject::connect(actionAbout, &QAction::triggered, this, [this]() {
         QMessageBox::about(this, "A propos",
                            "Barres\n"

--- a/student/dcm1/Window.h
+++ b/student/dcm1/Window.h
@@ -19,6 +19,10 @@
 class Barres;
 class QAction;
 class QCloseEvent;
+class QDragEnterEvent;
+class QDropEvent;
+class QSlider;
+struct MechanismParameters;
 
 class Window : public QMainWindow
 {
@@ -28,12 +32,25 @@ private:
     Barres  *viewer;
     QAction *actionStart;
     QAction *actionStop;
+    QSlider *sliderA1;
+    QSlider *sliderA2;
+    QSlider *sliderA3;
+    QSlider *sliderXb;
+    QSlider *sliderYa;
+    QSlider *sliderL;
+    QSlider *sliderE;
+    QSlider *sliderDp;
+
+    bool importParametersFromJsonFile(const QString &fileName);
+    void syncSlidersFromParameters(const MechanismParameters &p);
 
 public:
     explicit Window(QWidget *parent = nullptr);
 
 protected:
     void closeEvent(QCloseEvent *event) override;
+    void dragEnterEvent(QDragEnterEvent *event) override;
+    void dropEvent(QDropEvent *event) override;
 };
 
 #endif

--- a/student/dcm1/Window.h
+++ b/student/dcm1/Window.h
@@ -18,6 +18,7 @@
 #include <QMainWindow>
 class Barres;
 class QAction;
+class QCloseEvent;
 
 class Window : public QMainWindow
 {
@@ -30,6 +31,9 @@ private:
 
 public:
     explicit Window(QWidget *parent = nullptr);
+
+protected:
+    void closeEvent(QCloseEvent *event) override;
 };
 
 #endif

--- a/student/dcm1/i18n/barres_en.ts
+++ b/student/dcm1/i18n/barres_en.ts
@@ -1,0 +1,419 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="en">
+<context>
+    <name>Barres</name>
+    <message>
+        <source>Barres! (DCM1-1994)</source>
+        <translation>Bars! (DCM1-1994)</translation>
+    </message>
+</context>
+<context>
+    <name>MechanismRenderer</name>
+    <message>
+        <source>frame=%1/%2</source>
+        <translation>frame=%1/%2</translation>
+    </message>
+    <message>
+        <source>thetaAD=%1 deg
+thetaDC=%2 deg
+thetaBC=%3 deg</source>
+        <translation>thetaAD=%1 deg
+thetaDC=%2 deg
+thetaBC=%3 deg</translation>
+    </message>
+</context>
+<context>
+    <name>Window</name>
+    <message>
+        <source>Barres</source>
+        <translation>Bars</translation>
+    </message>
+    <message>
+        <source>Parameters</source>
+        <translation>Parameters</translation>
+    </message>
+    <message>
+        <source>Animation</source>
+        <translation>Animation</translation>
+    </message>
+    <message>
+        <source>Vitesse</source>
+        <translation>Speed</translation>
+    </message>
+    <message>
+        <source> ms/frame</source>
+        <translation> ms/frame</translation>
+    </message>
+    <message>
+        <source>Intervalle entre deux frames d&apos;animation</source>
+        <translation>Delay between two animation frames</translation>
+    </message>
+    <message>
+        <source>Vitesse animation: %1 ms/frame</source>
+        <translation>Animation speed: %1 ms/frame</translation>
+    </message>
+    <message>
+        <source>&amp;Fichier</source>
+        <translation>&amp;File</translation>
+    </message>
+    <message>
+        <source>&amp;Importer parametres...</source>
+        <translation>&amp;Import parameters...</translation>
+    </message>
+    <message>
+        <source>&amp;Exporter parametres...</source>
+        <translation>&amp;Export parameters...</translation>
+    </message>
+    <message>
+        <source>&amp;Quitter</source>
+        <translation>&amp;Quit</translation>
+    </message>
+    <message>
+        <source>&amp;Affichage</source>
+        <translation>&amp;View</translation>
+    </message>
+    <message>
+        <source>Réinitialiser la vue</source>
+        <translation>Reset view</translation>
+    </message>
+    <message>
+        <source>Parametres de dessin...</source>
+        <translation>Drawing settings...</translation>
+    </message>
+    <message>
+        <source>Langue</source>
+        <translation>Language</translation>
+    </message>
+    <message>
+        <source>Francais</source>
+        <translation>French</translation>
+    </message>
+    <message>
+        <source>Anglais</source>
+        <translation>English</translation>
+    </message>
+    <message>
+        <source>La langue sera appliquee au prochain demarrage.</source>
+        <translation>Language will be applied on next start.</translation>
+    </message>
+    <message>
+        <source>Preference de langue sauvegardee</source>
+        <translation>Language preference saved</translation>
+    </message>
+    <message>
+        <source>&amp;Animation</source>
+        <translation>&amp;Animation</translation>
+    </message>
+    <message>
+        <source>&amp;Démarrer</source>
+        <translation>&amp;Start</translation>
+    </message>
+    <message>
+        <source>&amp;Arrêter</source>
+        <translation>S&amp;top</translation>
+    </message>
+    <message>
+        <source>&amp;Aide</source>
+        <translation>&amp;Help</translation>
+    </message>
+    <message>
+        <source>&amp;A propos</source>
+        <translation>&amp;About</translation>
+    </message>
+    <message>
+        <source>Animation demarree</source>
+        <translation>Animation started</translation>
+    </message>
+    <message>
+        <source>Animation arretee</source>
+        <translation>Animation stopped</translation>
+    </message>
+    <message>
+        <source>Pret</source>
+        <translation>Ready</translation>
+    </message>
+    <message>
+        <source>Longueur AD (manivelle)</source>
+        <translation>AD length (crank)</translation>
+    </message>
+    <message>
+        <source>Longueur DC (bielle)</source>
+        <translation>DC length (connecting rod)</translation>
+    </message>
+    <message>
+        <source>Longueur BC (balancier)</source>
+        <translation>BC length (rocker)</translation>
+    </message>
+    <message>
+        <source>Position x du pivot B</source>
+        <translation>x position of pivot B</translation>
+    </message>
+    <message>
+        <source>Position y du pivot A</source>
+        <translation>y position of pivot A</translation>
+    </message>
+    <message>
+        <source>Longueur DP&apos; (point outil)</source>
+        <translation>DP&apos; length (tool point)</translation>
+    </message>
+    <message>
+        <source>Offset vertical du film</source>
+        <translation>Film vertical offset</translation>
+    </message>
+    <message>
+        <source>Distance P&apos; -&gt; P</source>
+        <translation>Distance P&apos; -&gt; P</translation>
+    </message>
+    <message>
+        <source>Importer les parametres</source>
+        <translation>Import parameters</translation>
+    </message>
+    <message>
+        <source>JSON files (*.json)</source>
+        <translation>JSON files (*.json)</translation>
+    </message>
+    <message>
+        <source>Exporter les parametres</source>
+        <translation>Export parameters</translation>
+    </message>
+    <message>
+        <source>Export impossible</source>
+        <translation>Export failed</translation>
+    </message>
+    <message>
+        <source>Impossible d&apos;ouvrir le fichier pour ecriture.</source>
+        <translation>Cannot open file for writing.</translation>
+    </message>
+    <message>
+        <source>Echec de l&apos;export JSON</source>
+        <translation>JSON export failed</translation>
+    </message>
+    <message>
+        <source>Export incomplet</source>
+        <translation>Incomplete export</translation>
+    </message>
+    <message>
+        <source>Le fichier n&apos;a pas ete ecrit completement.</source>
+        <translation>File was not written completely.</translation>
+    </message>
+    <message>
+        <source>Export JSON incomplet</source>
+        <translation>Incomplete JSON export</translation>
+    </message>
+    <message>
+        <source>Parametres exportes en JSON</source>
+        <translation>Parameters exported to JSON</translation>
+    </message>
+    <message>
+        <source>Parametres de dessin</source>
+        <translation>Drawing settings</translation>
+    </message>
+    <message>
+        <source>Traits</source>
+        <translation>Lines</translation>
+    </message>
+    <message>
+        <source>Epaisseur liens</source>
+        <translation>Link thickness</translation>
+    </message>
+    <message>
+        <source>Epaisseur trajectoire P</source>
+        <translation>P trajectory thickness</translation>
+    </message>
+    <message>
+        <source>Epaisseur trajectoire D</source>
+        <translation>D trajectory thickness</translation>
+    </message>
+    <message>
+        <source>Demi-longueur sol</source>
+        <translation>Ground half-length</translation>
+    </message>
+    <message>
+        <source>Longueur film</source>
+        <translation>Film length</translation>
+    </message>
+    <message>
+        <source>Labels</source>
+        <translation>Labels</translation>
+    </message>
+    <message>
+        <source>Taille police</source>
+        <translation>Font size</translation>
+    </message>
+    <message>
+        <source>Offset X</source>
+        <translation>Offset X</translation>
+    </message>
+    <message>
+        <source>Offset Y</source>
+        <translation>Offset Y</translation>
+    </message>
+    <message>
+        <source>Couleurs</source>
+        <translation>Colors</translation>
+    </message>
+    <message>
+        <source>Choisir...</source>
+        <translation>Choose...</translation>
+    </message>
+    <message>
+        <source>Couleur principale</source>
+        <translation>Main color</translation>
+    </message>
+    <message>
+        <source>Couleur trajectoire P</source>
+        <translation>P trajectory color</translation>
+    </message>
+    <message>
+        <source>Couleur trajectoire D</source>
+        <translation>D trajectory color</translation>
+    </message>
+    <message>
+        <source>Trajectoire P</source>
+        <translation>Trajectory P</translation>
+    </message>
+    <message>
+        <source>Trajectoire D</source>
+        <translation>Trajectory D</translation>
+    </message>
+    <message>
+        <source>Reinitialiser</source>
+        <translation>Reset</translation>
+    </message>
+    <message>
+        <source>Style de dessin applique</source>
+        <translation>Drawing style applied</translation>
+    </message>
+    <message>
+        <source>A propos</source>
+        <translation>About</translation>
+    </message>
+    <message>
+        <source>Barres
+Simulation d&apos;un mecanisme planar.
+Projet Qt Widgets / C++.
+
+Commandes:
+- Menu Fichier &gt; Quitter
+- Menu Animation &gt; Demarrer / Arreter
+- Sliders: reglage des parametres geometriques
+
+Raccourcis clavier:
+- Espace : demarrer / arreter l&apos;animation
+- R : reinitialiser a la frame 0
+- Fleche droite : frame suivante
+- Fleche gauche : frame precedente</source>
+        <translation>Bars
+Simulation of a planar mechanism.
+Qt Widgets / C++ project.
+
+Commands:
+- File menu &gt; Quit
+- Animation menu &gt; Start / Stop
+- Sliders: set geometric parameters
+
+Keyboard shortcuts:
+- Space: start / stop animation
+- R: reset to frame 0
+- Right arrow: next frame
+- Left arrow: previous frame</translation>
+    </message>
+    <message>
+        <source>Affichage de la boite A propos</source>
+        <translation>Showing About dialog</translation>
+    </message>
+    <message>
+        <source>Animation reinitialisee</source>
+        <translation>Animation reset</translation>
+    </message>
+    <message>
+        <source>Frame precedente</source>
+        <translation>Previous frame</translation>
+    </message>
+    <message>
+        <source>Frame suivante</source>
+        <translation>Next frame</translation>
+    </message>
+    <message>
+        <source>Deposer un fichier .json valide</source>
+        <translation>Drop a valid .json file</translation>
+    </message>
+    <message>
+        <source>Import impossible</source>
+        <translation>Import failed</translation>
+    </message>
+    <message>
+        <source>Impossible d&apos;ouvrir le fichier en lecture.</source>
+        <translation>Cannot open file for reading.</translation>
+    </message>
+    <message>
+        <source>Echec de l&apos;import JSON</source>
+        <translation>JSON import failed</translation>
+    </message>
+    <message>
+        <source>Format invalide</source>
+        <translation>Invalid format</translation>
+    </message>
+    <message>
+        <source>Le fichier JSON est invalide.</source>
+        <translation>JSON file is invalid.</translation>
+    </message>
+    <message>
+        <source>JSON invalide</source>
+        <translation>Invalid JSON</translation>
+    </message>
+    <message>
+        <source>Format non reconnu</source>
+        <translation>Unknown format</translation>
+    </message>
+    <message>
+        <source>Le fichier n&apos;est pas un export Barres.</source>
+        <translation>File is not a Barres export.</translation>
+    </message>
+    <message>
+        <source>Format JSON non reconnu</source>
+        <translation>Unknown JSON format</translation>
+    </message>
+    <message>
+        <source>Version non supportee</source>
+        <translation>Unsupported version</translation>
+    </message>
+    <message>
+        <source>Version de fichier non supportee.</source>
+        <translation>Unsupported file version.</translation>
+    </message>
+    <message>
+        <source>Version JSON non supportee</source>
+        <translation>Unsupported JSON version</translation>
+    </message>
+    <message>
+        <source>Fichier incomplet</source>
+        <translation>Incomplete file</translation>
+    </message>
+    <message>
+        <source>Objet &apos;params&apos; manquant.</source>
+        <translation>Missing &apos;params&apos; object.</translation>
+    </message>
+    <message>
+        <source>Objet params manquant</source>
+        <translation>Missing params object</translation>
+    </message>
+    <message>
+        <source>Parametres invalides</source>
+        <translation>Invalid parameters</translation>
+    </message>
+    <message>
+        <source>Un ou plusieurs parametres sont manquants ou hors bornes.</source>
+        <translation>One or more parameters are missing or out of range.</translation>
+    </message>
+    <message>
+        <source>Parametres JSON invalides</source>
+        <translation>Invalid JSON parameters</translation>
+    </message>
+    <message>
+        <source>Parametres importes depuis JSON</source>
+        <translation>Parameters imported from JSON</translation>
+    </message>
+</context>
+</TS>

--- a/student/dcm1/main.cpp
+++ b/student/dcm1/main.cpp
@@ -15,6 +15,7 @@
 #include "Window.h"
 #include <QApplication>
 #include <QCoreApplication>
+#include <QSettings>
 
 int
 main(int argc, char *argv[])
@@ -22,6 +23,11 @@ main(int argc, char *argv[])
     QApplication app(argc, argv);
     QCoreApplication::setOrganizationName("rboman");
     QCoreApplication::setApplicationName("barres");
+
+    // i18n step 1: define preferred UI language setting, not yet applied.
+    QSettings settings;
+    if (!settings.contains("ui/language"))
+        settings.setValue("ui/language", "fr");
 
     Window win;
     win.show();

--- a/student/dcm1/main.cpp
+++ b/student/dcm1/main.cpp
@@ -15,7 +15,9 @@
 #include "Window.h"
 #include <QApplication>
 #include <QCoreApplication>
+#include <QDir>
 #include <QSettings>
+#include <QTranslator>
 
 int
 main(int argc, char *argv[])
@@ -28,6 +30,20 @@ main(int argc, char *argv[])
     QSettings settings;
     if (!settings.contains("ui/language"))
         settings.setValue("ui/language", "fr");
+
+    const QString uiLanguage =
+        settings.value("ui/language", "fr").toString().toLower();
+    if (uiLanguage == "en")
+    {
+        QTranslator *translator = new QTranslator(&app);
+        const QString qmInI18nDir =
+            QDir(QCoreApplication::applicationDirPath()).filePath("i18n/barres_en.qm");
+        const QString qmNextToExe =
+            QDir(QCoreApplication::applicationDirPath()).filePath("barres_en.qm");
+
+        if (translator->load(qmInI18nDir) || translator->load(qmNextToExe))
+            app.installTranslator(translator);
+    }
 
     Window win;
     win.show();

--- a/student/dcm1/main.cpp
+++ b/student/dcm1/main.cpp
@@ -26,7 +26,7 @@ main(int argc, char *argv[])
     QCoreApplication::setOrganizationName("rboman");
     QCoreApplication::setApplicationName("barres");
 
-    // i18n step 1: define preferred UI language setting, not yet applied.
+    // Ensure a persisted UI language exists; translator is loaded at startup.
     QSettings settings;
     if (!settings.contains("ui/language"))
         settings.setValue("ui/language", "fr");


### PR DESCRIPTION

This PR introduces FR/EN internationalization for the Qt application using a safe, incremental approach.
UI strings were progressively externalized with tr(...) / QCoreApplication::translate(...).
Qt Linguist build integration was added in CMake, including TS/QM generation and runtime deployment of barres_en.qm.
A language preference (ui/language) is now persisted in QSettings, and a selector was added in View > Language (French/English).
Language changes are applied on next startup (no hot language switch in this PR).
Release build was validated after each increment, and the current English translation file is complete for the extracted strings.